### PR TITLE
ci: don't register repository if in Github actions

### DIFF
--- a/buildSrc/src/main/groovy/mdx.groovy-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/mdx.groovy-library-conventions.gradle
@@ -55,6 +55,11 @@ Closure pomInfo = {
     }
 }
 
+boolean isRunningInGithubActions = System.getenv('GITHUB_RUN_ID')
+boolean hasAwsSys = System.getProperty('aws.accessKeyId') && System.getProperty('aws.secretAccessKey')
+boolean hasAwsEnv = System.getenv('AWS_ACCESS_KEY_ID') && System.getenv('AWS_SECRET_ACCESS_KEY')
+boolean hasCodeArtifactProperties = project.hasProperty('awsCodeArtifactDomain') && project.hasProperty('awsCodeArtifactOwner') && project.hasProperty('awsCodeArtifactRepository') && project.hasProperty('awsCodeArtifactRegion')
+
 publishing {
     publications {
         groovyMaven(MavenPublication) {
@@ -65,9 +70,7 @@ publishing {
             pom pomInfo
         }
     }
-    if (project.hasProperty('awsCodeArtifactDomain') &&
-            project.hasProperty('awsCodeArtifactOwner') &&
-            project.hasProperty('awsCodeArtifactRepository')) {
+    if (hasCodeArtifactProperties && (!isRunningInGithubActions || (isRunningInGithubActions && (hasAwsSys || hasAwsEnv)))) {
         repositories {
             maven {
                 url "https://${awsCodeArtifactDomain}-${awsCodeArtifactOwner}.d.codeartifact.${awsCodeArtifactRegion}.amazonaws.com/maven/${awsCodeArtifactRepository}/"


### PR DESCRIPTION
Check if the build is running in Github actions. That it is when the GITHUB_RUN_ID environment variable is present.

If it is running in github actions unless the system properties 'aws.accessKeyId' / 'aws.secretAccessKey' or the environment variables AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY don't register the code artifact repository

see: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/ec2-iam-roles.html

see: see: https://metadata.atlassian.net/browse/EX-4472